### PR TITLE
[W6.2][W11-B4]Goh Wei Wen

### DIFF
--- a/src/seedu/addressbook/ui/DarkTheme.css
+++ b/src/seedu/addressbook/ui/DarkTheme.css
@@ -2,7 +2,7 @@
 
 .text-field {
     -fx-font-size: 12pt;
-    -fx-font-family: "Consolas";
+    -fx-font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
     -fx-font-weight: bold;
     -fx-text-fill: yellow;
     -fx-control-inner-background: derive(#1d1d1d,20%);
@@ -11,7 +11,7 @@
 .text-area {
     -fx-background-color: black;
     -fx-control-inner-background: black;
-    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-family: Menlo, Monaco, Consolas, 'Lucida Console', monospace;
     -fx-font-size: 10pt;
     -fx-padding: 5 5 5 5;
 }


### PR DESCRIPTION
This PR aims to add additional fallback fonts to the application's main theme.

Previously, the font-family attribute was set to a single font family, without any fallbacks. The default fonts were "Consolas" and "Segoe UI Semibold", which are Microsoft specific and do not ship with Linux or macOS.